### PR TITLE
mark private_key as sensitive

### DIFF
--- a/internal/provider/data_source_archive.go
+++ b/internal/provider/data_source_archive.go
@@ -44,6 +44,7 @@ func dataSourceArchive() *schema.Resource {
 				Optional:     true,
 				RequiredWith: []string{"certificate"},
 				Computed:     true,
+				Sensitive:    true,
 			},
 		},
 	}


### PR DESCRIPTION
Marks the `private_key` field as sensitive to ensure it is not displayed in printed plans